### PR TITLE
T_PHY_002 modified to address explicitely fault injection attacks

### DIFF
--- a/specification/src/chapter2.adoc
+++ b/specification/src/chapter2.adoc
@@ -553,7 +553,7 @@ a| * Using NVDIMM, interposers, or physical probing to read, record, or replay
 physical memory.
 a| * Implement robust memory error detection, cryptographic memory protection,
 or physical tamper resistance.
-* Supervisor domain ID, privilege level, or MTT attributes, may be used to
+* Supervisor domain ID, privilege level, or MPT attributes, may be used to
 derive memory encryption contexts at domain or workload granularity
 * Provide a degree of tamper resistance.
 

--- a/specification/src/chapter2.adoc
+++ b/specification/src/chapter2.adoc
@@ -544,13 +544,25 @@ Physical or remote
 a| * Implement robust power management and radiation control
 * Data Independent Execution Latency (Zkt, Zvkt)
 
+// Logical or physical
+// a| * Row-hammer type software attacks to manipulate nearby memory cells
+// * Using NVDIMM, interposers, or physical probing to read, record, or replay
+// physical memory
+// * Physical attacks on hardware shielded locations to extract hardware
+// provisioned assets
+// a| * Implement robust memory error detection, cryptographic memory protection,
+// or physical tamper resistance
+// * Supervisor domain ID, privilege level, or MTT attributes, may be used to
+// derive memory encryption contexts at domain or workload granularity
+// * Provide a degree of tamper resistance
+
 | T_PHY_002
 | Fault Injection
 | Direct +
 Logical or Physical
 a| * Row-hammer type software attacks to manipulate nearby memory cells  
-* Use of NVDIMM, interposers, or physical probing to read, record, or replay physical memory  
-* Fault injection (glitching, laser or electromagnetic) to extract hardware-provisioned assets  
+* Using NVDIMM, interposers, or physical probing to read, record, or replay physical memory  
+* Fault injection attacks (glitching, laser, electromagnetic, ...) to extract hardware-provisioned assets  
 a| * Implement robust memory error detection, cryptographic memory protection, or physical tamper resistance  
 * Use supervisor domain ID, privilege level, or MTT attributes to derive memory encryption contexts at the domain or workload granularity  
 * Provide a level of tamper resistance, e.g. through RoT attestation, adding redundancy during execution, etc.

--- a/specification/src/chapter2.adoc
+++ b/specification/src/chapter2.adoc
@@ -545,19 +545,17 @@ a| * Implement robust power management and radiation control
 * Data Independent Execution Latency (Zkt, Zvkt)
 
 | T_PHY_002
-| Physical memory manipulation
+| Fault Injection
 | Direct +
-Logical or physical
-a| * Row-hammer type software attacks to manipulate nearby memory cells
-* Using NVDIMM, interposers, or physical probing to read, record, or replay
-physical memory
-* Physical attacks on hardware shielded locations to extract hardware
-provisioned assets
-a| * Implement robust memory error detection, cryptographic memory protection,
-or physical tamper resistance
-* Supervisor domain ID, privilege level, or MTT attributes, may be used to
-derive memory encryption contexts at domain or workload granularity
-* Provide a degree of tamper resistance
+Logical or Physical
+a| * Row-hammer type software attacks to manipulate nearby memory cells  
+* Use of NVDIMM, interposers, or physical probing to read, record, or replay physical memory  
+* Fault injection (glitching, laser or electromagnetic) to extract hardware-provisioned assets  
+a| * Implement robust memory error detection, cryptographic memory protection, or physical tamper resistance  
+* Use supervisor domain ID, privilege level, or MTT attributes to derive memory encryption contexts at the domain or workload granularity  
+* Provide a level of tamper resistance, e.g. through RoT attestation, adding redundancy during execution, etc.
+* Employ lockstep processors for security-critical devices  
+
 
 | T_PHY_003
 | Boot attacks

--- a/specification/src/chapter2.adoc
+++ b/specification/src/chapter2.adoc
@@ -544,18 +544,6 @@ Physical or remote
 a| * Implement robust power management and radiation control
 * Data Independent Execution Latency (Zkt, Zvkt)
 
-// Logical or physical
-// a| * Row-hammer type software attacks to manipulate nearby memory cells
-// * Using NVDIMM, interposers, or physical probing to read, record, or replay
-// physical memory
-// * Physical attacks on hardware shielded locations to extract hardware
-// provisioned assets
-// a| * Implement robust memory error detection, cryptographic memory protection,
-// or physical tamper resistance
-// * Supervisor domain ID, privilege level, or MTT attributes, may be used to
-// derive memory encryption contexts at domain or workload granularity
-// * Provide a degree of tamper resistance
-
 | T_PHY_002
 | Fault Injection
 | Direct +

--- a/specification/src/chapter2.adoc
+++ b/specification/src/chapter2.adoc
@@ -544,17 +544,21 @@ Physical or remote
 a| * Implement robust power management and radiation control
 * Data Independent Execution Latency (Zkt, Zvkt)
 
+
 | T_PHY_002
-| Fault Injection
+| Physical memory manipulation
 | Direct +
-Logical or Physical
-a| * Row-hammer type software attacks to manipulate nearby memory cells  
-* Using NVDIMM, interposers, or physical probing to read, record, or replay physical memory  
-* Fault injection attacks (glitching, laser, electromagnetic, ...) to extract hardware-provisioned assets  
-a| * Implement robust memory error detection, cryptographic memory protection, or physical tamper resistance  
-* Use supervisor domain ID, privilege level, or MTT attributes to derive memory encryption contexts at the domain or workload granularity  
-* Provide a level of tamper resistance, e.g. through RoT attestation, adding redundancy during execution, etc.
-* Employ lockstep processors for security-critical devices  
+Logical or physical
+a| * Using NVDIMM, interposers, or physical probing to read, record, or replay
+physical memory.
+a| * Implement robust memory error detection, cryptographic memory protection,
+or physical tamper resistance.
+* Supervisor domain ID, privilege level, or MTT attributes, may be used to
+derive memory encryption contexts at domain or workload granularity
+* Provide a degree of tamper resistance.
+
+// * Physical attacks on hardware shielded locations to extract hardware
+// provisioned assets
 
 
 | T_PHY_003
@@ -578,6 +582,18 @@ processes, development processes (for example, unfused development hardware or
 debug authorizations)
 | Deploy appropriate governance, accreditation, and certification processes for
 an ecosystem.
+
+| T_PHY_005
+| Fault Injection
+| Direct or remote +
+Logical or physical
+a| * Rowhammer-type software attacks to manipulate nearby memory cells.
+* Fault injection attacks (glitching, laser, electromagnetic, etc.) to extract hardware-provisioned assets, modify the control flow, circumvent countermeasures, etc.
+a| * Implement robust memory error detection, cryptographic memory protection, or physical tamper resistance. 
+* Provide a level of tamper resistance, e.g., through RoT attestation, redundancy during execution, etc.
+* Enforce proper access control for the DVFS configuration.
+* Employ lockstep processors for security-critical devices.
+
 
 |===
 

--- a/specification/src/chapter2.adoc
+++ b/specification/src/chapter2.adoc
@@ -593,7 +593,7 @@ a| * Implement robust memory error detection, cryptographic memory protection, o
 * Provide a level of tamper resistance, e.g., through RoT attestation, redundancy during execution, etc.
 * Enforce proper access control for the DVFS configuration.
 * Employ lockstep processors for security-critical devices.
-
+* Employ physical sensors to detect attack
 
 |===
 


### PR DESCRIPTION
As discussed in #49, a new formulation for T_PHY_002 addressing explicitly fault injection.